### PR TITLE
Casmhms 5597

### DIFF
--- a/generate-build-metadata/action.yaml
+++ b/generate-build-metadata/action.yaml
@@ -34,7 +34,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - shell: bash

--- a/generate-build-metadata/action.yaml
+++ b/generate-build-metadata/action.yaml
@@ -36,7 +36,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.10
     - shell: bash
       id: generate_build_metadata
       env:

--- a/generate-build-metadata/action.yaml
+++ b/generate-build-metadata/action.yaml
@@ -36,7 +36,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - shell: bash
       id: generate_build_metadata
       env:

--- a/generate-build-metadata/generate_build_metadata.py
+++ b/generate-build-metadata/generate_build_metadata.py
@@ -107,5 +107,8 @@ print("Helm Suffix:  ", result["helm"])
 print("Docker Suffix:", result["docker"])
 print()
 
-for name in result:
-    print("::set-output name={}::{}".format(name, result[name]))
+with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
+    for name in result:
+        output = "{}={}\n".format(name, result[name])
+        print(output)
+        f.write(output)    


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
[The ::set-output command is deprecated, and will be disabled in May of 2023. ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

- Updated the setup-python action to v4 to remove depercation warnings. 
- Changed the generate_build_metadata.py to no longer use `::set-output`

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

These changes have been tested in this github action run, while testing changes to the HMS build workflows: https://github.com/Cray-HPE/hms-canary/actions/runs/3679099574/jobs/6260603293



## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

